### PR TITLE
Reload page after swear jar creation.

### DIFF
--- a/swear_jar.rb
+++ b/swear_jar.rb
@@ -97,7 +97,8 @@ class SwearJar < Sinatra::Application
   post '/jar' do
     entity_id = session.dig(:accounts, 0, :entity_id)
     bank.account!(entity_id: entity_id, name: SWEAR_JAR_NAME)
-    redirect '/'
+    content_type :json
+    halt 200
   end
 
   post '/jar/swear' do

--- a/test/functional/swear_jar_test.rb
+++ b/test/functional/swear_jar_test.rb
@@ -42,7 +42,7 @@ describe SwearJar do
       expect_any_instance_of(RestClient::Request).to receive(:execute)
         .and_return(response_stub)
       response = post '/jar'
-      expect(response.status).to eq(302)
+      expect(response.status).to eq(200)
     end
   end
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -113,8 +113,7 @@
     </div>
     <script>
       function createSwearJar() {
-        fetch('/jar', { method: 'POST' })
-        console.log('creating!')
+        fetch('/jar', { method: 'POST' }).then(location.reload())
       }
     </script>
     <script


### PR DESCRIPTION
Because this is a JavaScript function-called request, there's also no need for the redirect.